### PR TITLE
fix provision

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.planner.launch/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.planner.launch/META-INF/MANIFEST.MF
@@ -19,4 +19,5 @@ Require-Bundle: org.eclipse.debug.ui;bundle-version="3.14.700",
  org.palladiosimulator.analyzer.slingshot.workflow.events,
  org.palladiosimulator.analyzer.slingshot.ui.events,
  org.palladiosimulator.analyzer.slingshot.stateexploration.data,
- org.palladiosimulator.analyzer.slingshot.planner
+ org.palladiosimulator.analyzer.slingshot.planner,
+ org.palladiosimulator.analyzer.slingshot.workflow

--- a/org.palladiosimulator.analyzer.slingshot.planner.launch/src/org/palladiosimulator/analyzer/slingshot/workflow/planner/configuration/PlannerWorkflowConfiguration.java
+++ b/org.palladiosimulator.analyzer.slingshot.planner.launch/src/org/palladiosimulator/analyzer/slingshot/workflow/planner/configuration/PlannerWorkflowConfiguration.java
@@ -1,62 +1,25 @@
 package org.palladiosimulator.analyzer.slingshot.workflow.planner.configuration;
 
-import java.util.LinkedList;
-import java.util.List;
+
 import java.util.Map;
 
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationConfiguration;
+import org.palladiosimulator.analyzer.slingshot.workflow.SimulationWorkflowConfiguration;
 import org.palladiosimulator.analyzer.slingshot.workflow.events.PCMWorkflowConfiguration;
-import org.palladiosimulator.analyzer.workflow.configurations.AbstractPCMWorkflowRunConfiguration;
 
 import de.uka.ipd.sdq.simucomframework.SimuComConfig;
 
-public class PlannerWorkflowConfiguration extends AbstractPCMWorkflowRunConfiguration implements PCMWorkflowConfiguration, SimulationConfiguration {
+public class PlannerWorkflowConfiguration extends SimulationWorkflowConfiguration implements PCMWorkflowConfiguration, SimulationConfiguration {
 
-		private final SimuComConfig simuComConfig;
-		private final Map<String, Object> launchConfigurationParams;
-		private List<String> otherFiles;
+	private final Map<String, Object> launchConfigurationParams;
 
-		public PlannerWorkflowConfiguration(final SimuComConfig configuration, final Map<String, Object> launchConfigurationParams) {
-			this.simuComConfig = configuration;
-			this.launchConfigurationParams = launchConfigurationParams;
-		}
-
-		@Override
-		public String getErrorMessage() {
-			// TODO Auto-generated method stub
-			return null;
-		}
-
-		@Override
-		public void setDefaults() {
-			// TODO Auto-generated method stub
-		}
-
-		@Override
-		public SimuComConfig getSimuComConfig() {
-			return this.simuComConfig;
-		}
-
-		@Override
-		public List<String> getPCMModelFiles() {
-			final List<String> files = super.getPCMModelFiles();
-			if (this.otherFiles != null) {
-				files.addAll(this.otherFiles);
-			}
-			return files;
-		}
-
-		@Override
-		public void addOtherModelFile(final String modelFile) {
-			if (this.otherFiles == null) {
-				this.otherFiles = new LinkedList<>();
-			}
-			this.otherFiles.add(modelFile);
-		}
-
-		public Map<String, Object> getlaunchConfigParams() {
-			return this.launchConfigurationParams;
-		}
-
+	public PlannerWorkflowConfiguration(final SimuComConfig configuration, final Map<String, Object> launchConfigurationParams) {
+		super(configuration);
+		this.launchConfigurationParams = launchConfigurationParams;
 	}
 
+	public Map<String, Object> getlaunchConfigParams() {
+		return this.launchConfigurationParams;
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
@@ -37,9 +37,7 @@ import org.palladiosimulator.edp2.impl.RepositoryManager;
 import org.palladiosimulator.edp2.models.ExperimentData.ExperimentGroup;
 import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
 import org.palladiosimulator.edp2.models.Repository.Repository;
-import org.palladiosimulator.monitorrepository.MonitorRepository;
 import org.palladiosimulator.pcm.allocation.Allocation;
-import org.palladiosimulator.semanticspd.Configuration;
 
 import de.uka.ipd.sdq.simucomframework.SimuComConfig;
 
@@ -74,24 +72,24 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 	private final boolean activated;
 
 	private final Allocation allocation;
-	private final MonitorRepository monitoring;
-	private final Configuration configuration;
 
 	@Inject
 	public SnapshotGraphStateBehaviour(final @Nullable DefaultState halfDoneState,
 			final @Nullable SnapshotConfiguration snapshotConfig, final @Nullable SimuComConfig simuComConfig,
-			final @Nullable Set<DESEvent> eventsToInitOn, final Allocation allocation,
-			final MonitorRepository monitoring, final Configuration configuration) {
+			final Allocation allocation) {
 		this.halfDoneState = halfDoneState;
 		this.snapshotConfig = snapshotConfig;
 		this.simuComConfig = simuComConfig;
-		this.eventsToInitOn = eventsToInitOn;
 		this.allocation = allocation;
-		this.monitoring = monitoring;
-		this.configuration = configuration;
 
-		this.activated = this.halfDoneState != null && this.snapshotConfig != null && this.simuComConfig != null
-				&& eventsToInitOn != null;
+		this.activated = this.halfDoneState != null && this.snapshotConfig != null && this.simuComConfig != null;
+
+		if (activated && halfDoneState.getSnapshot() != null) {
+			this.eventsToInitOn = halfDoneState.getSnapshot().getEvents();
+			this.halfDoneState.setSnapshot(null);
+		} else {
+			this.eventsToInitOn = null;
+		}
 
 		this.event2offset = new HashMap<>();
 	}

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotTriggeringBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotTriggeringBehavior.java
@@ -10,6 +10,7 @@ import javax.measure.quantity.Duration;
 
 import org.apache.log4j.Logger;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjustmentRequested;
+import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationScheduling;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.PreIntercept;
@@ -46,13 +47,20 @@ public class SnapshotTriggeringBehavior implements SimulationBehaviorExtension {
 
 	private final int minNumberOfMeasurementsForAvg = 5;
 
+	private final boolean activated;
 
 	@Inject
-	public SnapshotTriggeringBehavior(final DefaultState state, final SimulationScheduling scheduling) {
+	public SnapshotTriggeringBehavior(final @Nullable DefaultState state, final SimulationScheduling scheduling) {
 		this.state = state;
 		this.scheduling = scheduling;
+
+		this.activated = state != null;
 	}
 
+	@Override
+	public boolean isActive() {
+		return this.activated;
+	}
 
 	@Subscribe
 	public Result<SnapshotInitiated> onMeasurementMade(final MeasurementMade event) {

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
@@ -30,6 +30,10 @@ public class DefaultState implements RawModelState {
 
 	/* known at the end */
 	private double duration;
+	/**
+	 * at first misused to get the snapshot to init on into the simulation. Later on
+	 * set to the actual snapshot of the events at the end of this state.
+	 */
 	private Snapshot snapshot;
 	private ReasonToLeave reasonToLeave;
 	private boolean decreaseInterval = false;

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/plugin.xml
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/plugin.xml
@@ -4,7 +4,11 @@
    <extension
          point="org.palladiosimulator.analyzer.slingshot">
       <slingshot-extension
-            module="org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.ExplorationModule"></slingshot-extension>
+            module="org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.ExplorationModule">
+      </slingshot-extension>
+      <slingshot-extension
+            module="org.palladiosimulator.analyzer.slingshot.ui.workflow.planner.providers.AdditionalConfigurationModule">
+      </slingshot-extension>
    </extension>
 
 </plugin>

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/DefaultExplorationPlanner.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/DefaultExplorationPlanner.java
@@ -69,6 +69,8 @@ public class DefaultExplorationPlanner {
 
 		this.reduceSimulationTimeTriggerExpectedTime(end.getArchitecureConfiguration().getSPD(), start.getDuration());
 
+		end.setSnapshot(start.getSnapshot()); // get the old snapshot into the next simulation run.
+
 		return createConfigBasedOnChange(next.getChange(), start, end);
 
 	}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/ui/workflow/planner/providers/AdditionalConfigurationModule.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/ui/workflow/planner/providers/AdditionalConfigurationModule.java
@@ -1,0 +1,26 @@
+package org.palladiosimulator.analyzer.slingshot.ui.workflow.planner.providers;
+
+import org.palladiosimulator.analyzer.slingshot.core.extension.AbstractSlingshotExtension;
+import org.palladiosimulator.analyzer.slingshot.snapshot.configuration.SnapshotConfiguration;
+import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultState;
+
+public class AdditionalConfigurationModule extends AbstractSlingshotExtension {
+
+	public static final SnapConfigProvider snapConfigProvider = new SnapConfigProvider();
+	public static final DefaultStateProvider defaultStateProvider = new DefaultStateProvider();
+
+	public AdditionalConfigurationModule() {
+	}
+
+	@Override
+	protected void configure() {
+		bind(SnapshotConfiguration.class).toProvider(snapConfigProvider);
+		bind(DefaultState.class).toProvider(defaultStateProvider);
+
+	}
+
+	@Override
+	public String getName() {
+		return "Additional Configuration";
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/ui/workflow/planner/providers/DefaultStateProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/ui/workflow/planner/providers/DefaultStateProvider.java
@@ -1,0 +1,29 @@
+package org.palladiosimulator.analyzer.slingshot.ui.workflow.planner.providers;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultState;
+
+import de.uka.ipd.sdq.simucomframework.SimuComConfig;
+
+/**
+ * A provider for the {@link SimuComConfig} object that holds
+ * all the information about the simulation.
+ *
+ */
+@Singleton
+public class DefaultStateProvider implements Provider<DefaultState> {
+
+	private DefaultState config;
+
+	public void set(final DefaultState config) {
+		this.config = config;
+	}
+
+	@Override
+	public DefaultState get() {
+		return config;
+	}
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/ui/workflow/planner/providers/SnapConfigProvider.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/ui/workflow/planner/providers/SnapConfigProvider.java
@@ -1,0 +1,29 @@
+package org.palladiosimulator.analyzer.slingshot.ui.workflow.planner.providers;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.palladiosimulator.analyzer.slingshot.snapshot.configuration.SnapshotConfiguration;
+
+import de.uka.ipd.sdq.simucomframework.SimuComConfig;
+
+/**
+ * A provider for the {@link SimuComConfig} object that holds
+ * all the information about the simulation.
+ *
+ */
+@Singleton
+public class SnapConfigProvider implements Provider<SnapshotConfiguration> {
+
+	private SnapshotConfiguration config;
+
+	public void set(final SnapshotConfiguration config) {
+		this.config = config;
+	}
+
+	@Override
+	public SnapshotConfiguration get() {
+		return config;
+	}
+
+}


### PR DESCRIPTION
# Current
Provide injectibles for snapshot and exploration via private Submodule. Problem: cant properly deactiveate the snapshot behaviours.

# New 
Provide injectibles for snapshot and exploration via normal Provider. Make them nullable and deactivate snapshot behaviour if incetibles are not provided. 

Benefit: it is possible to start normal slingshot simulations even when the exploration plugins are active. 