### PR TITLE
Use UsageEvolution with State exploration.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelper.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelper.java
@@ -5,9 +5,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.apache.log4j.Logger;
+import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.ActiveJob;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.Job;
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.entities.jobs.LinkingJob;
@@ -27,12 +33,17 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.Use
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.ClosedWorkloadUserInterpretationContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.OpenWorkloadUserInterpretationContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.interpretationcontext.UserInterpretationContext;
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.scenariobehavior.BranchScenarioContext;
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.scenariobehavior.LoopScenarioBehaviorContext;
+import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.scenariobehavior.RootScenarioContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.scenariobehavior.UsageScenarioBehaviorContext;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.ClosedWorkloadUserInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.InterArrivalUserInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageModelPassedElement;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.cost.events.IntervalPassed;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
+import org.palladiosimulator.pcm.allocation.AllocationContext;
 import org.palladiosimulator.pcm.core.CoreFactory;
 import org.palladiosimulator.pcm.core.PCMRandomVariable;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
@@ -40,9 +51,14 @@ import org.palladiosimulator.pcm.parameter.VariableUsage;
 import org.palladiosimulator.pcm.repository.OperationProvidedRole;
 import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.repository.ProvidedRole;
+import org.palladiosimulator.pcm.repository.RequiredRole;
+import org.palladiosimulator.pcm.repository.Signature;
+import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
 import org.palladiosimulator.pcm.seff.AbstractAction;
 import org.palladiosimulator.pcm.seff.ResourceDemandingBehaviour;
+import org.palladiosimulator.pcm.seff.seff_performance.ParametricResourceDemand;
 import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
+import org.palladiosimulator.pcm.usagemodel.ScenarioBehaviour;
 import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.UsageScenario;
 
@@ -51,7 +67,7 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
 /**
  * Helper to create deep copies of entities.
  *
- *
+ * Also updates the referenced PCM models.
  *
  * @author stiesssh
  *
@@ -59,6 +75,12 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe;
 public final class CloneHelper {
 
 	public static final Logger LOGGER = Logger.getLogger(CloneHelper.class);
+
+	private final PCMResourceSetPartition set;
+
+	public CloneHelper(final PCMResourceSetPartition set) {
+		this.set = set;
+	}
 
 	/**
 	 * TODO on a closer look : what is this does not belong here, iirc o_O
@@ -151,7 +173,7 @@ public final class CloneHelper {
 		return new ClosedWorkloadUserInitiated(cloneUserInterpretationContext(event.getEntity()), newThinktime);
 	}
 
-	// getter for various entity clones
+	// Operations for cloning the entities //
 
 	/**
 	 *
@@ -171,6 +193,9 @@ public final class CloneHelper {
 
 	/**
 	 *
+	 * Need not match the {@code ProcessingResourceType} as they are defined in the
+	 * {@code ResourceRepository}
+	 *
 	 * @param job
 	 * @return
 	 * @throws CloningFailedException
@@ -178,14 +203,21 @@ public final class CloneHelper {
 	public Job clone(final ActiveJob job) {
 		final ResourceDemandRequest clonedRequest = clone(job.getRequest());
 
+
+		final AllocationContext matchedAllocContext = getMatchingPCMElement(job.getAllocationContext());
+
+
 		final Job clonedJob = ActiveJob.builder().withDemand(job.getDemand()).withId(job.getId())
 				.withProcessingResourceType(job.getProcessingResourceType()).withRequest(clonedRequest)
-				.withAllocationContext(job.getAllocationContext()).build();
+				.withAllocationContext(matchedAllocContext).build();
 
 		return clonedJob;
 	}
 
 	/**
+	 * TODO
+	 *
+	 * Does not yet work due to problems with cloning the Call Over Wire Requests.
 	 *
 	 * @param job
 	 * @return
@@ -194,7 +226,9 @@ public final class CloneHelper {
 	public Job clone(final LinkingJob job) {
 		final CallOverWireRequest clonedRequest = clone(job.getRequest());
 
-		final Job clonedJob = new LinkingJob(job.getId(), job.getDemand(), job.getLinkingResource(), clonedRequest);
+		final LinkingResource matchee = getMatchingPCMElement(job.getLinkingResource());
+
+		final Job clonedJob = new LinkingJob(job.getId(), job.getDemand(), matchee, clonedRequest);
 
 		return clonedJob;
 	}
@@ -214,8 +248,12 @@ public final class CloneHelper {
 
 		final SimulatedStackframe<Object> variablesToConsider = user.getStack().currentStackFrame();
 
-		final CallOverWireRequest.Builder clonedRequestBuilder = CallOverWireRequest.builder().from(request.getFrom())
-				.to(request.getTo()).signature(request.getSignature()).user(user).entryRequest(clonedEntryRequest)
+		final AssemblyContext from = getMatchingPCMElement(request.getFrom());
+		final AssemblyContext to = getMatchingPCMElement(request.getTo());
+		final Signature signature = getMatchingPCMElement(request.getSignature());
+
+		final CallOverWireRequest.Builder clonedRequestBuilder = CallOverWireRequest.builder().from(from)
+				.to(to).signature(signature).user(user).entryRequest(clonedEntryRequest)
 				.variablesToConsider(variablesToConsider);
 
 		if (request.getReplyTo().isPresent()) {
@@ -228,7 +266,7 @@ public final class CloneHelper {
 
 	/**
 	 * NESTED
-	 * 
+	 *
 	 * @param request
 	 * @return
 	 */
@@ -242,8 +280,12 @@ public final class CloneHelper {
 
 		final SimulatedStackframe<Object> variablesToConsider = user.getStack().currentStackFrame();
 
-		final CallOverWireRequest.Builder clonedRequestBuilder = CallOverWireRequest.builder().from(request.getFrom())
-				.to(request.getTo()).signature(request.getSignature()).user(user).entryRequest(clonedEntryRequest)
+		final AssemblyContext from = getMatchingPCMElement(request.getFrom());
+		final AssemblyContext to = getMatchingPCMElement(request.getTo());
+		final Signature signature = getMatchingPCMElement(request.getSignature());
+
+		final CallOverWireRequest.Builder clonedRequestBuilder = CallOverWireRequest.builder().from(from)
+				.to(to).signature(signature).user(user).entryRequest(clonedEntryRequest)
 				.variablesToConsider(variablesToConsider);
 
 		if (request.getReplyTo().isPresent()) {
@@ -264,10 +306,13 @@ public final class CloneHelper {
 
 		final SEFFInterpretationContext context = cloneContext(resourceDemandRequest.getSeffInterpretationContext());
 
+		final AssemblyContext assemblyContext = getMatchingPCMElement(resourceDemandRequest.getAssemblyContext());
+		final ParametricResourceDemand rd = getMatchingPCMElement(resourceDemandRequest.getParametricResourceDemand());
+
 		final ResourceDemandRequest clonedRequest = ResourceDemandRequest.builder()
 				.withResourceType(resourceDemandRequest.getResourceType()).withSeffInterpretationContext(context)
-				.withAssemblyContext(resourceDemandRequest.getAssemblyContext())
-				.withParametricResourceDemand(resourceDemandRequest.getParametricResourceDemand()).build();
+				.withAssemblyContext(assemblyContext)
+				.withParametricResourceDemand(rd).build();
 
 		return clonedRequest;
 	}
@@ -280,7 +325,7 @@ public final class CloneHelper {
 	 */
 	public SEFFInterpretationContext cloneContext(final SEFFInterpretationContext context) {
 
-		final AssemblyContext assemblyContext = context.getAssemblyContext();
+		final AssemblyContext assemblyContext = getMatchingPCMElement(context.getAssemblyContext());
 
 		// 1 define all content.
 		SEFFInterpretationContext clonedParent = null;
@@ -315,10 +360,10 @@ public final class CloneHelper {
 		}
 
 		if (context.getCallOverWireRequest().isPresent()) { // TODO probably like above
-//			if (calledFrom == null) {
-//				throw new IllegalStateException(
-//						"If the Call over wire is present, there must also be a caller (i think)!");
-//			}
+			//			if (calledFrom == null) {
+			//				throw new IllegalStateException(
+			//						"If the Call over wire is present, there must also be a caller (i think)!");
+			//			}
 			clonedCallOverWireRequest = clone(context.getCallOverWireRequest().get(), calledFrom);
 		}
 
@@ -332,17 +377,17 @@ public final class CloneHelper {
 
 	/**
 	 * TODO
-	 * 
+	 *
 	 * @param holder
 	 * @return
 	 */
 	public SeffBehaviorContextHolder cloneSeffBehaviorContextHolder(final SeffBehaviorContextHolder holder,
 			final SeffBehaviorWrapper clonedParentWrapper) {
 
-		if (holder instanceof RootBehaviorContextHolder rootholder) {
+		if (holder instanceof final RootBehaviorContextHolder rootholder) {
 			return cloneRootBehaviorContextHolder(rootholder);
 		}
-		if (holder instanceof BranchBehaviorContextHolder branchholder) {
+		if (holder instanceof final BranchBehaviorContextHolder branchholder) {
 			return cloneBranchBehaviorContextHolder(branchholder, clonedParentWrapper);
 		}
 		throw new IllegalArgumentException(
@@ -353,12 +398,13 @@ public final class CloneHelper {
 	 *
 	 * @param holder
 	 * @return
-	 * @throws CloningFailedException
+	 *
 	 */
 	public SeffBehaviorContextHolder cloneRootBehaviorContextHolder(final RootBehaviorContextHolder holder) {
 
-		final ResourceDemandingBehaviour behaviour = holder.getCurrentProcessedBehavior().getBehavior();
-		final AbstractAction current = holder.getCurrentProcessedBehavior().getCurrentAction();
+		final ResourceDemandingBehaviour behaviour = getMatchingPCMElement(
+				holder.getCurrentProcessedBehavior().getBehavior());
+		final AbstractAction current = getMatchingPCMElement(holder.getCurrentProcessedBehavior().getCurrentAction());
 
 		final SeffBehaviorContextHolder clonedHolder = new RootBehaviorContextHolder(behaviour);
 
@@ -370,7 +416,7 @@ public final class CloneHelper {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param branchedholder
 	 * @param clonedParent
 	 * @return
@@ -379,12 +425,15 @@ public final class CloneHelper {
 			final SeffBehaviorWrapper clonedParent) {
 
 		SeffBehaviorContextHolder clonedHolder = null;
-		final ResourceDemandingBehaviour behaviour = branchedholder.getCurrentProcessedBehavior().getBehavior();
-		final AbstractAction current = branchedholder.getCurrentProcessedBehavior().getCurrentAction();
+		final ResourceDemandingBehaviour behaviour = getMatchingPCMElement(
+				branchedholder.getCurrentProcessedBehavior().getBehavior());
+		final AbstractAction current = getMatchingPCMElement(
+				branchedholder.getCurrentProcessedBehavior().getCurrentAction());
 
 		// PCM element -> no cloning
-		final AbstractAction successor = branchedholder.getSuccessor().isPresent() ? branchedholder.getSuccessor().get()
-				: null;
+		final AbstractAction successor = branchedholder.getSuccessor().isPresent()
+				? getMatchingPCMElement(branchedholder.getSuccessor().get())
+						: null;
 
 		clonedHolder = new BranchBehaviorContextHolder(behaviour, successor, clonedParent);
 
@@ -414,16 +463,16 @@ public final class CloneHelper {
 	public RequestProcessingContext cloneRequestProcessingContext(
 			final RequestProcessingContext requestProcessingContext) {
 
-		final ProvidedRole opProvidedRole = requestProcessingContext.getProvidedRole();
-		final AssemblyContext assmemblyContext = requestProcessingContext.getAssemblyContext();
+		final ProvidedRole opProvidedRole = getMatchingPCMElement(requestProcessingContext.getProvidedRole());
+		final AssemblyContext assmemblyContext = getMatchingPCMElement(requestProcessingContext.getAssemblyContext());
 
 		// Because right now, they might in fact be legitly null :/
 
 		final User clonedUser = cloneUser(requestProcessingContext.getUser());
 
-		UserInterpretationContext clonedUserInterpretationContext = cloneUserInterpretationContext(
+		final UserInterpretationContext clonedUserInterpretationContext = cloneUserInterpretationContext(
 				requestProcessingContext.getUserInterpretationContext(), clonedUser);
-		UserRequest clonedUserRequest = cloneUserRequest(requestProcessingContext.getUserRequest(), clonedUser);
+		final UserRequest clonedUserRequest = cloneUserRequest(requestProcessingContext.getUserRequest(), clonedUser);
 
 		final RequestProcessingContext clonedRequestProcessingContext = RequestProcessingContext.builder()
 				.withUser(clonedUser).withUserRequest(clonedUserRequest)
@@ -435,9 +484,9 @@ public final class CloneHelper {
 
 	/**
 	 *
-	 * @param userRequest
-	 * @return
-	 * @throws CloningFailedException
+	 *
+	 * @param userRequest the request to be cloned. be ware, it might be null.
+	 * @return cloned user request, or null, if the request is null.
 	 */
 	public UserRequest cloneUserRequest(final UserRequest userRequest) {
 
@@ -462,9 +511,10 @@ public final class CloneHelper {
 			return null;
 		}
 
-		final OperationProvidedRole opProvidedRole = userRequest.getOperationProvidedRole();
-		final OperationSignature signature = userRequest.getOperationSignature();
-		final EList<VariableUsage> inputParameterUsages = userRequest.getVariableUsages();
+		final OperationProvidedRole opProvidedRole = getMatchingPCMElement(userRequest.getOperationProvidedRole());
+		final OperationSignature signature = getMatchingPCMElement(userRequest.getOperationSignature());
+		final EList<VariableUsage> inputParameterUsages = new BasicEList<>(
+				userRequest.getVariableUsages().stream().map(usage -> getMatchingPCMElement(usage)).toList());
 
 		final UserRequest clonedUserRequest = UserRequest.builder().withUser(user)
 				.withOperationProvidedRole(opProvidedRole).withOperationSignature(signature)
@@ -480,9 +530,8 @@ public final class CloneHelper {
 	 * What the fuck to my former self, but also i guess this saves my ass wrt to
 	 * the stack?
 	 *
-	 * @param user
-	 * @return
-	 * @throws CloningFailedException
+	 * @param user the user to be cloned
+	 * @return clone of the given user.
 	 */
 	public User cloneUser(final User user) {
 		try (ByteArrayOutputStream fileOutputStream = new ByteArrayOutputStream();
@@ -506,10 +555,11 @@ public final class CloneHelper {
 	}
 
 	/**
+	 * Redirect without user.
 	 *
+	 * @see
 	 * @param userInterpretationContext
 	 * @return
-	 * @throws CloningFailedException
 	 */
 	public UserInterpretationContext cloneUserInterpretationContext(
 			final UserInterpretationContext userInterpretationContext) {
@@ -522,6 +572,14 @@ public final class CloneHelper {
 				cloneUser(userInterpretationContext.getUser()));
 	}
 
+	/**
+	 *
+	 * Actual clone operation
+	 *
+	 * @param userInterpretationContext
+	 * @param clonedUser
+	 * @return
+	 */
 	public UserInterpretationContext cloneUserInterpretationContext(
 			final UserInterpretationContext userInterpretationContext, final User clonedUser) {
 
@@ -538,28 +596,24 @@ public final class CloneHelper {
 		// }
 
 		UserInterpretationContext clonedUserInterpretationContext = null;
-		final AbstractUserAction firstAction = userInterpretationContext.getCurrentAction();
+		final AbstractUserAction firstAction = this.getMatchingPCMElement(userInterpretationContext.getCurrentAction());
+		final UsageScenario usageScenario = this.getMatchingPCMElement(userInterpretationContext.getScenario());
+		final UsageScenarioBehaviorContext scenarioContext = cloneUsageScenarioBehaviorContext(
+				userInterpretationContext.getBehaviorContext());
 
 		if (userInterpretationContext instanceof ClosedWorkloadUserInterpretationContext) {
 
-			final UsageScenario usageScenario = userInterpretationContext.getScenario();
 			final ThinkTime thinkTime = ((ClosedWorkloadUserInterpretationContext) userInterpretationContext)
 					.getThinkTime();
 
-			final UsageScenarioBehaviorContext scenarioContext = cloneUsageScenarioBehaviorContext(
-					userInterpretationContext.getBehaviorContext());
 
 			clonedUserInterpretationContext = ClosedWorkloadUserInterpretationContext.builder()
 					.withUser(clonedUser).withScenario(usageScenario)
 					.withCurrentAction(firstAction).withThinkTime(thinkTime)
 					.withUsageScenarioBehaviorContext(scenarioContext).build();
 		} else {
-			final UsageScenario usageScenario = userInterpretationContext.getScenario();
 			final InterArrivalTime interArrivalTime = ((OpenWorkloadUserInterpretationContext) userInterpretationContext)
 					.getInterArrivalTime();
-
-			final UsageScenarioBehaviorContext scenarioContext = cloneUsageScenarioBehaviorContext(
-					userInterpretationContext.getBehaviorContext());
 
 			clonedUserInterpretationContext = OpenWorkloadUserInterpretationContext.builder()
 					.withUser(clonedUser).withScenario(usageScenario)
@@ -578,15 +632,38 @@ public final class CloneHelper {
 	 */
 	public UsageScenarioBehaviorContext cloneUsageScenarioBehaviorContext(
 			final UsageScenarioBehaviorContext scenarioContext) {
-		// TODO ich will jetzt erstmal durch das SEFF durchkommen...
-		// the only reason this has not yet broken my leg, is because i always work with
-		// root scenarios of a single action.
 
-		// RootScenarioContext clonedScenarioContext = RootScenarioContext.builder()
-		// .withScenarioBehavior(scenarioContext.getScenarioBehavior())
-		// .build();
+		UsageScenarioBehaviorContext clonedContext;
 
-		return scenarioContext;
+		final ScenarioBehaviour scenarioBehaviour = getMatchingPCMElement(scenarioContext.getScenarioBehavior());
+
+		final Optional<AbstractUserAction> abstractUserAction = scenarioContext.getNextAction().isPresent()
+				? Optional.of(getMatchingPCMElement(scenarioContext.getNextAction().get()))
+						: Optional.empty();
+
+		if (scenarioContext instanceof RootScenarioContext) {
+
+			clonedContext = RootScenarioContext.builder()
+					.withNextAction(abstractUserAction)
+					// .withParent() no parent for root
+					.withScenarioBehavior(scenarioBehaviour)
+					.build();
+
+			// TODO : Dont care about "current action, as it is updated by the enclosing
+			// Interpretaiton context(?)"
+		} else if (scenarioContext instanceof BranchScenarioContext) {
+			throw new IllegalArgumentException("Not yet Implemented");
+
+		} else if (scenarioContext instanceof LoopScenarioBehaviorContext) {
+			throw new IllegalArgumentException("Not yet Implemented");
+
+		} else {
+			throw new IllegalArgumentException(String.format("Unexpected %s of type %s",
+					UsageScenarioBehaviorContext.class.getSimpleName(), scenarioContext.getClass().getSimpleName()));
+		}
+
+
+		return clonedContext;
 	}
 
 	/**
@@ -597,25 +674,33 @@ public final class CloneHelper {
 	 * @throws CloningFailedException
 	 */
 	public GeneralEntryRequest cloneGeneralEntryRequest(final GeneralEntryRequest generalEntryRequest) {
-		
-		SEFFInterpretationContext clonedContext = cloneContext(generalEntryRequest.getRequestFrom());
+
+		final SEFFInterpretationContext clonedContext = cloneContext(generalEntryRequest.getRequestFrom());
+
+		final EList<VariableUsage> inputParameterUsages = new BasicEList<>(
+				generalEntryRequest.getInputVariableUsages().stream().map(usage -> getMatchingPCMElement(usage))
+				.toList());
+		final EList<VariableUsage> outputParameterUsages = new BasicEList<>(
+				generalEntryRequest.getOutputVariableUsages().stream().map(usage -> getMatchingPCMElement(usage))
+				.toList());
+		final RequiredRole requiredRole = getMatchingPCMElement(generalEntryRequest.getRequiredRole());
+		final Signature signature = getMatchingPCMElement(generalEntryRequest.getSignature());
 
 		final GeneralEntryRequest clonedGeneralEntryRequest = GeneralEntryRequest.builder()
-				.withInputVariableUsages(generalEntryRequest.getInputVariableUsages())
-				.withOutputVariableUsages(generalEntryRequest.getOutputVariableUsages())
+				.withInputVariableUsages(inputParameterUsages)
+				.withOutputVariableUsages(outputParameterUsages)
 				.withRequestFrom(clonedContext)
-				.withRequiredRole(generalEntryRequest.getRequiredRole())
-				.withSignature(generalEntryRequest.getSignature())
+				.withRequiredRole(requiredRole)
+				.withSignature(signature)
 				.withUser(clonedContext.getRequestProcessingContext().getUser())
 				.build();
-
 
 		return clonedGeneralEntryRequest;
 	}
 
 	/**
 	 * Cloning Nested {@link GeneralEntryRequest}s.
-	 * 
+	 *
 	 * Must reference the same caller {@link SEFFInterpretationContext} as the
 	 * enclosing context.
 	 *
@@ -626,13 +711,22 @@ public final class CloneHelper {
 	public GeneralEntryRequest cloneGeneralEntryRequest(final GeneralEntryRequest generalEntryRequest,
 			final SEFFInterpretationContext SEFFIC_requestFrom) {
 
-		SEFFInterpretationContext clonedSEFFIC = SEFFIC_requestFrom.update().withCaller(SEFFIC_requestFrom).build();
+		final SEFFInterpretationContext clonedSEFFIC = SEFFIC_requestFrom.update().withCaller(SEFFIC_requestFrom).build();
+
+		final EList<VariableUsage> inputParameterUsages = new BasicEList<>(
+				generalEntryRequest.getInputVariableUsages().stream().map(usage -> getMatchingPCMElement(usage))
+				.toList());
+		final EList<VariableUsage> outputParameterUsages = new BasicEList<>(
+				generalEntryRequest.getOutputVariableUsages().stream().map(usage -> getMatchingPCMElement(usage))
+				.toList());
+		final RequiredRole requiredRole = getMatchingPCMElement(generalEntryRequest.getRequiredRole());
+		final Signature signature = getMatchingPCMElement(generalEntryRequest.getSignature());
 
 		final GeneralEntryRequest clonedGeneralEntryRequest = GeneralEntryRequest.builder()
-				.withInputVariableUsages(generalEntryRequest.getInputVariableUsages())
-				.withOutputVariableUsages(generalEntryRequest.getOutputVariableUsages()).withRequestFrom(clonedSEFFIC)
-				.withRequiredRole(generalEntryRequest.getRequiredRole())
-				.withSignature(generalEntryRequest.getSignature())
+				.withInputVariableUsages(inputParameterUsages)
+				.withOutputVariableUsages(outputParameterUsages).withRequestFrom(clonedSEFFIC)
+				.withRequiredRole(requiredRole)
+				.withSignature(signature)
 				.withUser(SEFFIC_requestFrom.getRequestProcessingContext().getUser()).build();
 
 		return clonedGeneralEntryRequest;
@@ -640,20 +734,46 @@ public final class CloneHelper {
 
 	/**
 	 * TODO
-	 * 
+	 *
+	 * @param <T>
+	 *
 	 * @param seffBehaviorWrapper
 	 * @return
 	 */
-//	public SeffBehaviorWrapper cloneSeffBehaviorWrapper(final SeffBehaviorWrapper seffBehaviorWrapper) {
-//
-//		final ResourceDemandingBehaviour rdBehaviour = seffBehaviorWrapper.getBehavior();
-//		final SeffBehaviorContextHolder clonedSeffBehaviorContextHolder = cloneSeffBehaviorContextHolder(
-//				seffBehaviorWrapper.getContext(), null);
-//
-//		final SeffBehaviorWrapper clonedSeffBehaviorWrapper = new SeffBehaviorWrapper(rdBehaviour,
-//				clonedSeffBehaviorContextHolder);
-//
-//		return clonedSeffBehaviorWrapper;
-//	}
+	//	public SeffBehaviorWrapper cloneSeffBehaviorWrapper(final SeffBehaviorWrapper seffBehaviorWrapper) {
+	//
+	//		final ResourceDemandingBehaviour rdBehaviour = seffBehaviorWrapper.getBehavior();
+	//		final SeffBehaviorContextHolder clonedSeffBehaviorContextHolder = cloneSeffBehaviorContextHolder(
+	//				seffBehaviorWrapper.getContext(), null);
+	//
+	//		final SeffBehaviorWrapper clonedSeffBehaviorWrapper = new SeffBehaviorWrapper(rdBehaviour,
+	//				clonedSeffBehaviorContextHolder);
+	//
+	//		return clonedSeffBehaviorWrapper;
+	//	}
+
+	/**
+	 * Finds a model element in {@code this} helper's resource set that is equal to
+	 * the given element.
+	 *
+	 *
+	 * @param <T>     Type of the element to be matched
+	 * @param element element to be matched
+	 * @return matching element from {@code this}' resource set.
+	 */
+	private <T extends EObject> T getMatchingPCMElement(final T element) {
+		final String fragment = EcoreUtil.getURI(element).fragment();
+
+		final Resource opt = set.getResourceSet().getResources().stream()
+				.filter(r -> element.eResource().getClass().isInstance(r)).findFirst()
+				.orElseThrow(() -> new NoSuchElementException(
+						String.format("No matching resource for %s", element.eResource().getClass().getSimpleName())));
+
+		final T matchedElement = (T) opt.getEObject(fragment);
+
+		assert matchedElement != null : String.format("Missing Element for fragment %s", fragment);
+
+		return matchedElement;
+	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelper.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelper.java
@@ -758,10 +758,13 @@ public final class CloneHelper {
 	 *
 	 *
 	 * @param <T>     Type of the element to be matched
-	 * @param element element to be matched
+	 * @param element element to be matched, must be contained in a resource.
 	 * @return matching element from {@code this}' resource set.
 	 */
 	private <T extends EObject> T getMatchingPCMElement(final T element) {
+		assert element.eResource() != null
+				: String.format("Element %s is not contained in a resource, but must be.", element.toString());
+
 		final String fragment = EcoreUtil.getURI(element).fragment();
 
 		final Resource opt = set.getResourceSet().getResources().stream()

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/JobEventVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/JobEventVisitor.java
@@ -3,9 +3,9 @@ package org.palladiosimulator.analyzer.slingshot.behavior.util.visitors;
 import java.util.function.Function;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.resourcesimulation.events.JobInitiated;
-import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelper;
 import org.palladiosimulator.analyzer.slingshot.behavior.util.LambdaVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 /**
  * We drop all but the JobInitiated Events, because we must send them again anyway.
@@ -14,35 +14,36 @@ import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
  * @author stiesssh
  *
  */
-public class JobEventVisitor {
+public class JobEventVisitor extends SetReferencingVisitor {
 
-    private final Function<DESEvent, DESEvent> jobCloneFactory;
-	private final CloneHelper helper = new CloneHelper();
+	private final Function<DESEvent, DESEvent> jobCloneFactory;
 
-    public JobEventVisitor() {
-    	jobCloneFactory = new LambdaVisitor<DESEvent, DESEvent>().
-                on(JobInitiated.class).then(this::clone);
-                //on(JobFinished.class).then(this::clone).
-                //on(JobProgressed.class).then(this::clone).
-                //on(ProcessorSharingJobProgressed.class).then(this::clone);
+	public JobEventVisitor(final PCMResourceSetPartition set) {
+		super(set);
+
+		jobCloneFactory = new LambdaVisitor<DESEvent, DESEvent>().
+				on(JobInitiated.class).then(this::clone);
+		//on(JobFinished.class).then(this::clone).
+		//on(JobProgressed.class).then(this::clone).
+		//on(ProcessorSharingJobProgressed.class).then(this::clone);
 	}
 
 	private DESEvent clone(final JobInitiated clonee) {
 		return new JobInitiated(helper.clone(clonee.getEntity()));
 	}
 
-//	private DESEvent clone(final JobFinished clonee) {
-//		return new JobFinished(helper.clone(clonee.getEntity()));
-//	}
+	//	private DESEvent clone(final JobFinished clonee) {
+	//		return new JobFinished(helper.clone(clonee.getEntity()));
+	//	}
 
-//	private DESEvent clone(final JobProgressed clonee) {
-//		return new JobProgressed(helper.clone(clonee.getEntity()), );
-//	}
-//
-//	private DESEvent clone(final ProcessorSharingJobProgressed clonee) {
-//		final Job clonedJob = helper.clone(clonee.getEntity());
-//		return new ProcessorSharingJobProgressed(clonedJob, clonee.getDelay(), clonee.getExpectedState());
-//	}
+	//	private DESEvent clone(final JobProgressed clonee) {
+	//		return new JobProgressed(helper.clone(clonee.getEntity()), );
+	//	}
+	//
+	//	private DESEvent clone(final ProcessorSharingJobProgressed clonee) {
+	//		final Job clonedJob = helper.clone(clonee.getEntity());
+	//		return new ProcessorSharingJobProgressed(clonedJob, clonee.getDelay(), clonee.getExpectedState());
+	//	}
 
 	public DESEvent visit(final DESEvent e) {
 		return this.jobCloneFactory.apply(e);

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/ModelElementPassedVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/ModelElementPassedVisitor.java
@@ -3,18 +3,17 @@ package org.palladiosimulator.analyzer.slingshot.behavior.util.visitors;
 import java.util.function.Function;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageModelPassedElement;
-import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelper;
 import org.palladiosimulator.analyzer.slingshot.behavior.util.LambdaVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.Stop;
 
-public class ModelElementPassedVisitor {
-    private final Function<DESEvent, DESEvent> jobCloneFactory;
+public class ModelElementPassedVisitor extends SetReferencingVisitor {
+	private final Function<DESEvent, DESEvent> jobCloneFactory;
 
-	private final CloneHelper helper = new CloneHelper();
-
-	public ModelElementPassedVisitor() {
+	public ModelElementPassedVisitor(final PCMResourceSetPartition set) {
+		super(set);
 		jobCloneFactory = new LambdaVisitor<DESEvent, DESEvent>().
 				on(UsageModelPassedElement.class).then(this::clone);
 	}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/SEFFInterpretedVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/SEFFInterpretedVisitor.java
@@ -6,15 +6,15 @@ import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFExternalActionCalled;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFInterpretationFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.systemsimulation.events.SEFFInterpretationProgressed;
-import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelper;
 import org.palladiosimulator.analyzer.slingshot.behavior.util.LambdaVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
-public class SEFFInterpretedVisitor {
+public class SEFFInterpretedVisitor extends SetReferencingVisitor {
 	private final Function<DESEvent, DESEvent> cloneFactory;
-	private final CloneHelper helper = new CloneHelper();
 
-	public SEFFInterpretedVisitor() {
+	public SEFFInterpretedVisitor(final PCMResourceSetPartition set) {
+		super(set);
 		cloneFactory = new LambdaVisitor<DESEvent, DESEvent>()
 				.on(SEFFInterpretationProgressed.class).then(this::clone)
 				.on(SEFFInterpretationFinished.class).then(this::clone)

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/SetReferencingVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/SetReferencingVisitor.java
@@ -1,0 +1,13 @@
+package org.palladiosimulator.analyzer.slingshot.behavior.util.visitors;
+
+import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelper;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
+
+public class SetReferencingVisitor {
+
+	protected final CloneHelper helper;
+
+	public SetReferencingVisitor(final PCMResourceSetPartition set) {
+		this.helper = new CloneHelper(set);
+	}
+}

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/UserChangedEventVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/visitors/UserChangedEventVisitor.java
@@ -7,17 +7,18 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.entities.int
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.ClosedWorkloadUserInitiated;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserFinished;
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UserStarted;
-import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelper;
 import org.palladiosimulator.analyzer.slingshot.behavior.util.LambdaVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 import org.palladiosimulator.pcm.core.CoreFactory;
 import org.palladiosimulator.pcm.core.PCMRandomVariable;
 
-public class UserChangedEventVisitor {
+public class UserChangedEventVisitor extends SetReferencingVisitor {
 	private final Function<DESEvent, DESEvent> visitor;
-	private final CloneHelper helper = new CloneHelper();
 
-	public UserChangedEventVisitor() {
+	public UserChangedEventVisitor(final PCMResourceSetPartition set) {
+		super(set);
+
 		this.visitor = new LambdaVisitor<DESEvent, DESEvent>()
 				.on(ClosedWorkloadUserInitiated.class).then(this::clone)
 				.on(UserFinished.class).then(this::clone)

--- a/org.palladiosimulator.analyzer.slingshot.snapshot.data/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot.data/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.apache.log4j,
  org.palladiosimulator.analyzer.slingshot.common,
  org.palladiosimulator.analyzer.slingshot.core,
  org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
- org.palladiosimulator.analyzer.slingshot.cost
+ org.palladiosimulator.analyzer.slingshot.cost,
+ org.palladiosimulator.analyzer.workflow
 Export-Package: org.palladiosimulator.analyzer.slingshot.snapshot.api,
  org.palladiosimulator.analyzer.slingshot.snapshot.configuration,
  org.palladiosimulator.analyzer.slingshot.snapshot.entities,

--- a/org.palladiosimulator.analyzer.slingshot.snapshot.data/src/org/palladiosimulator/analyzer/slingshot/snapshot/api/Snapshot.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot.data/src/org/palladiosimulator/analyzer/slingshot/snapshot/api/Snapshot.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjustmentRequested;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 /**
  * TODO
@@ -19,7 +20,7 @@ public interface Snapshot {
 	 *
 	 * @return
 	 */
-	public Set<DESEvent> getEvents();
+	public Set<DESEvent> getEvents(final PCMResourceSetPartition set);
 
 	/**
 	 * Adjustor of the reactive reconfiguration, if a reactive reconfiguration happened to end the state.

--- a/org.palladiosimulator.analyzer.slingshot.snapshot.data/src/org/palladiosimulator/analyzer/slingshot/snapshot/entities/InMemorySnapshot.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot.data/src/org/palladiosimulator/analyzer/slingshot/snapshot/entities/InMemorySnapshot.java
@@ -7,6 +7,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjustmen
 import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelperWithVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.snapshot.api.Snapshot;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 /**
  *
@@ -31,8 +32,8 @@ public final class InMemorySnapshot implements Snapshot {
 
 
 	@Override
-	public Set<DESEvent> getEvents() {
-		final CloneHelperWithVisitor cloneHelper = new CloneHelperWithVisitor();
+	public Set<DESEvent> getEvents(final PCMResourceSetPartition set) {
+		final CloneHelperWithVisitor cloneHelper = new CloneHelperWithVisitor(set);
 		return cloneHelper.clone(this.events);
 	}
 

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/META-INF/MANIFEST.MF
@@ -26,5 +26,6 @@ Require-Bundle: org.apache.log4j,
  org.palladiosimulator.analyzer.slingshot.stateexploration.data,
  org.palladiosimulator.spd.semantic,
  org.palladiosimulator.analyzer.slingshot.cost,
- org.palladiosimulator.analyzer.slingshot.stateexploration
+ org.palladiosimulator.analyzer.slingshot.stateexploration,
+ org.palladiosimulator.analyzer.workflow
 Export-Package: org.palladiosimulator.analyzer.slingshot.snapshot

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/META-INF/MANIFEST.MF
@@ -27,5 +27,6 @@ Require-Bundle: org.apache.log4j,
  org.palladiosimulator.spd.semantic,
  org.palladiosimulator.analyzer.slingshot.cost,
  org.palladiosimulator.analyzer.slingshot.stateexploration,
- org.palladiosimulator.analyzer.workflow
+ org.palladiosimulator.analyzer.workflow,
+ org.palladiosimulator.analyzer.slingshot.behavior.usageevolution
 Export-Package: org.palladiosimulator.analyzer.slingshot.snapshot

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
@@ -1,6 +1,5 @@
 package org.palladiosimulator.analyzer.slingshot.snapshot;
 
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +15,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.Usage
 import org.palladiosimulator.analyzer.slingshot.common.annotations.Nullable;
 import org.palladiosimulator.analyzer.slingshot.common.events.AbstractEntityChangedEvent;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
+import org.palladiosimulator.analyzer.slingshot.common.utils.events.ModelPassedEvent;
 import org.palladiosimulator.analyzer.slingshot.core.events.PreSimulationConfigurationStarted;
 import org.palladiosimulator.analyzer.slingshot.core.events.SimulationFinished;
 import org.palladiosimulator.analyzer.slingshot.core.events.SimulationStarted;
@@ -47,7 +47,7 @@ import de.uka.ipd.sdq.simucomframework.SimuComConfig;
  *
  * Behavioural Extension to handle everything related to the RawGraphState.
  *
- * @author stiesssh
+ * @author Sarah Stieß
  *
  */
 @OnEvent(when = CalculatorRegistered.class, then = {})
@@ -70,7 +70,6 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 
 	/* helper */
 	private final Map<UsageModelPassedElement<?>, Double> event2offset;
-
 	private final Map<String, IntervalPassed> resourceContainer2intervalPassed;
 
 	private final boolean activated;
@@ -79,7 +78,8 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 
 	@Inject
 	public SnapshotGraphStateBehaviour(final @Nullable DefaultState halfDoneState,
-			final @Nullable SnapshotConfiguration snapshotConfig, final @Nullable EventsToInitOnWrapper eventsToInitOn, final @Nullable SimuComConfig simuComConfig,
+			final @Nullable SnapshotConfiguration snapshotConfig, final @Nullable EventsToInitOnWrapper eventsToInitOn,
+			final @Nullable SimuComConfig simuComConfig,
 			final Allocation allocation) {
 
 		assert halfDoneState.getSnapshot() == null : "Snapshot already set!";
@@ -124,7 +124,8 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 	 * Start the simulation run with the snapshotted events from an earlier
 	 * simulation run.
 	 *
-	 * Return (and thereby submit for scheduling the snapshotted events from
+	 * Return (and thereby submit for scheduling) the snapshotted events from
+	 * earlier simulation run.
 	 *
 	 * @param simulationStarted
 	 * @return
@@ -176,7 +177,8 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 	}
 
 	/**
-	 * Catch ModelPassedEvent from the snapshot and offset them into the past.
+	 * Catch {@link ModelPassedEvent} from the snapshot and offset them into the
+	 * past.
 	 *
 	 * @param information interception information
 	 * @param event       intercepted event
@@ -194,6 +196,14 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 		return InterceptionResult.success();
 	}
 
+	/**
+	 * Catch {@link IntervalPassed} (cost) from the snapshot abort them, because for
+	 * costs, we use the events of the current simulation run.
+	 *
+	 * @param information interception information
+	 * @param event       intercepted event
+	 * @return always success
+	 */
 	@PreIntercept
 	public InterceptionResult preInterceptIntervalPassed(final InterceptorInformation information,
 			final IntervalPassed event) {
@@ -252,10 +262,19 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 		this.halfDoneState.setExperimentSetting(settings.get(0));
 	}
 
+	/**
+	 *
+	 * Catch {@link IntervalPassed} events (usage evolution) from the snapshot and
+	 * offset them into the "future". Otherwise, we will get the wrong values from
+	 * the Load Intensity model.
+	 *
+	 * @param information interception information
+	 * @param event       intercepted event
+	 * @return always success
+	 */
 	@PreIntercept
 	public InterceptionResult preInterceptIntervalPassed(final InterceptorInformation information,
 			final org.palladiosimulator.analyzer.slingshot.behavior.usageevolution.events.IntervalPassed event) {
-
 		event.setTime(event.time() + halfDoneState.getStartTime());
 		return InterceptionResult.success();
 	}
@@ -301,6 +320,12 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 		});
 	}
 
+	/**
+	 * Collect resource containers, for which an {@link IntervalPassed} event must
+	 * be aborted later on.
+	 *
+	 * @param events events to collect resource containers from.
+	 */
 	private void initIntervallPased(final Set<DESEvent> events) {
 		events.stream().filter(event -> event instanceof IntervalPassed)
 		.forEach(event -> resourceContainer2intervalPassed

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
@@ -252,6 +252,14 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 		this.halfDoneState.setExperimentSetting(settings.get(0));
 	}
 
+	@PreIntercept
+	public InterceptionResult preInterceptIntervalPassed(final InterceptorInformation information,
+			final org.palladiosimulator.analyzer.slingshot.behavior.usageevolution.events.IntervalPassed event) {
+
+		event.setTime(event.time() + halfDoneState.getStartTime());
+		return InterceptionResult.success();
+	}
+
 	/**
 	 *
 	 * NB : state is complete.

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotRecordingBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotRecordingBehavior.java
@@ -14,6 +14,7 @@ import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjustmen
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageModelPassedElement;
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationEngine;
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationScheduling;
+import org.palladiosimulator.analyzer.slingshot.core.extension.PCMResourceSetPartitionProvider;
 import org.palladiosimulator.analyzer.slingshot.core.extension.SimulationBehaviorExtension;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.PostIntercept;
 import org.palladiosimulator.analyzer.slingshot.eventdriver.annotations.PreIntercept;
@@ -58,11 +59,13 @@ public class SnapshotRecordingBehavior implements SimulationBehaviorExtension {
 
 	@Inject
 	public SnapshotRecordingBehavior(final SimulationEngine engine, final Allocation allocation,
-			final MonitorRepository monitorRepository, final SimulationScheduling scheduling) {
+			final MonitorRepository monitorRepository, final SimulationScheduling scheduling,
+			final PCMResourceSetPartitionProvider set) {
 		// can i somehow include this in the injection part?
 		// should work with this Model an the 'bind' instruction.
+
 		this.recorder = new LessInvasiveInMemoryRecord();
-		this.camera = new LessInvasiveInMemoryCamera(this.recorder, engine);
+		this.camera = new LessInvasiveInMemoryCamera(this.recorder, engine, set.get());
 		this.scheduling = scheduling;
 	}
 
@@ -86,7 +89,7 @@ public class SnapshotRecordingBehavior implements SimulationBehaviorExtension {
 	/**
 	 * Create JobRecord before the {@link JobInitiated} get processed, with initial
 	 * demand.
-	 * 
+	 *
 	 * @param information
 	 * @param event
 	 * @return
@@ -103,7 +106,7 @@ public class SnapshotRecordingBehavior implements SimulationBehaviorExtension {
 	/**
 	 * Update JobRecord after the {@link JobInitiated} got processed, to set
 	 * normalized demand.
-	 * 
+	 *
 	 * @param information
 	 * @param event
 	 * @param result
@@ -148,7 +151,7 @@ public class SnapshotRecordingBehavior implements SimulationBehaviorExtension {
 		// Cast to ActiveJob is feasible, because LinkingJobs are always FCFS.
 		this.scheduleProcSharingUpdatesHelper(
 				recorder.getProcSharingJobRecords().stream().map(record -> (ActiveJob) record.getJob())
-						.collect(Collectors.toSet()));
+				.collect(Collectors.toSet()));
 
 		return Result.of(new SnapshotTaken(0, snapshotInitiated.getTriggeringEvent()));
 	}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: org.palladiosimulator.monitorrepository,
  org.palladiosimulator.spd.semantic,
  org.jgrapht.core;bundle-version="1.5.0",
  org.palladiosimulator.analyzer.slingshot.behavior.spd.data,
- org.palladiosimulator.analyzer.slingshot.common.utils
+ org.palladiosimulator.analyzer.slingshot.common.utils,
+ org.scaledl.usageevolution

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/ArchitectureConfigurationUtil.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/ArchitectureConfigurationUtil.java
@@ -18,6 +18,7 @@ import org.palladiosimulator.pcm.usagemodel.UsagemodelPackage;
 import org.palladiosimulator.semanticspd.SemanticspdPackage;
 import org.palladiosimulator.servicelevelobjective.ServicelevelObjectivePackage;
 import org.palladiosimulator.spd.SpdPackage;
+import org.scaledl.usageevolution.UsageevolutionPackage;
 
 /**
  *
@@ -35,7 +36,8 @@ public class ArchitectureConfigurationUtil {
 			MonitorRepositoryPackage.eINSTANCE.getMonitorRepository(),
 			MeasuringpointPackage.eINSTANCE.getMeasuringPointRepository(), SpdPackage.eINSTANCE.getSPD(),
 			SemanticspdPackage.eINSTANCE.getConfiguration(),
-			ServicelevelObjectivePackage.eINSTANCE.getServiceLevelObjectiveRepository());
+			ServicelevelObjectivePackage.eINSTANCE.getServiceLevelObjectiveRepository(),
+			UsageevolutionPackage.eINSTANCE.getUsageEvolution());
 
 	/**
 	 * Get all {@link Resource}s from the given {@link ResourceSet} that contain a

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/DefaultGraphExplorer.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/DefaultGraphExplorer.java
@@ -47,7 +47,7 @@ import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
  *
  * Responsible for starting the simulation runs to explore different branches.
  *
- * @author stiesssh
+ * @author Sarah Stieß
  *
  */
 public class DefaultGraphExplorer implements GraphExplorer {
@@ -202,32 +202,26 @@ public class DefaultGraphExplorer implements GraphExplorer {
 	 * otherwise {@link SimulationFinished} gets scheduled before
 	 * {@link SnapshotInitiated}.
 	 *
-	 * TODO set variation id to something meaningfull, e.g. archConfig x change
-	 *
-	 * TODO set experiment run to something meaning full
-	 *
-	 * @param variation
+	 * @param variation name of the variation.
 	 * @param duration  duration of the interval in seconds.
-	 * @return
+	 * @return {@link SimuComConfig} for the next simulation run.
 	 */
 	private SimuComConfig prepareSimuComConfig(final String variation, final double duration) {
 		// MapHelper.getValue(configuration, VARIATION_ID, String.class)
 		launchConfigurationParams.put(SimuComConfig.SIMULATION_TIME, String.valueOf(((long) duration) + 1));
 		launchConfigurationParams.put(SimuComConfig.VARIATION_ID, variation);
 		launchConfigurationParams.put(SimuComConfig.EXPERIMENT_RUN, this.graph.toString());
-		// launchConfigurationParams.put(SimuComConfig.SIMULATION_TIME,
-		// String.valueOf(((long) duration) + 1));
 
 		return new SimuComConfig(launchConfigurationParams, true);
 	}
 
 	/**
+	 * Create a {@link SnapshotConfiguration} required to start a new simulation
+	 * run.
 	 *
-	 * Create the SnapshotConfiguration required to start a new simulation run.
-	 *
-	 * @param interval between two snapshots
-	 * @param init     wether or not to init on a snapshot.
-	 * @return
+	 * @param config Information from which to build the next
+	 *               {@link SnapshotConfiguration}
+	 * @return new {@link SnapshotConfiguration}
 	 */
 	private SnapshotConfiguration createSnapConfig(final SimulationInitConfiguration config) {
 
@@ -272,7 +266,7 @@ public class DefaultGraphExplorer implements GraphExplorer {
 	 * Get {@link ExplorationConfiguration.MIN_STATE_DURATION} from launch
 	 * configuration parameters map.
 	 *
-	 * @return min duration of a exploration cycles
+	 * @return minimum duration of an exploration cycles
 	 */
 	private double getMinDuration() {
 		final String minDuration = (String) launchConfigurationParams


### PR DESCRIPTION
**!!** Requires repo `Palladio-Analyzer-Slingshot-Extension-PCM-Core` on branch `stateexplorationRequirements-usageevolution` (if this PR passes, i gonna merge both.)

## Current 
StateExploration does not consider UsageEvolution.

## New
StateExploration does consider UsageEvolution.
Notably, to achieve this, all PCM elements in copied events must be updated. This is reasonable anyway, but i ignored it previously because all earlier problems could be fixed by relying on IDs instead of object identity.