### PR TITLE
Make use of JGraph Library (and split Fringe from Graph)

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/RawModelState.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/RawModelState.java
@@ -1,7 +1,5 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.api;
 
-import java.util.Set;
-
 import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
 
 /**
@@ -26,13 +24,6 @@ public interface RawModelState {
 	 * @return
 	 */
 	public ExperimentSetting getMeasurements();
-
-	/**
-	 * Get RawTransitions that start at the current state.
-	 *
-	 * @return
-	 */
-	public Set<RawTransition> getOutTransitions();
 
 	/**
 	 * Get the point in time the state started

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/RawModelState.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/RawModelState.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.api;
 
+import java.util.Set;
+
 import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
 
 /**
@@ -10,6 +12,10 @@ import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
  *
  */
 public interface RawModelState {
+
+	public RawTransition getIncomingTransition();
+
+	public Set<RawTransition> getOutgoingTransitions();
 
 	/**
 	 * Get everything PCM.

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/RawTransition.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/api/RawTransition.java
@@ -1,14 +1,11 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.api;
 
 import java.util.Optional;
-import java.util.Set;
 
 import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.Change;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.EnvironmentChange;
-import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.ModelElementDifference;
-import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.ReactiveReconfiguration;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.ProactiveReconfiguration;
-import org.palladiosimulator.pcm.core.entity.Entity;
+import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.ReactiveReconfiguration;
 
 /**
  * Transition between two RawModelStates.
@@ -43,15 +40,6 @@ public interface RawTransition {
 	 * @return
 	 */
 	public Optional<Change> getChange();
-
-	/**
-	 * actually, you can also calculate this from the source and target model instances.
-	 * dont know whether it makes sense to provide this.
-	 *
-	 * @return
-	 */
-	public Set<ModelElementDifference<Entity>> getModelDifferences();
-
 
 	/**
 	 *

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultGraph.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultGraph.java
@@ -65,21 +65,21 @@ public class DefaultGraph extends SimpleDirectedWeightedGraph<RawModelState, Raw
 
 	public boolean hasInFringe(final DefaultState state, final ScalingPolicy matchee) {
 		return this.fringe.stream()
-				.filter(todo -> todo.getStart().equals(state) && todo.getChange().isPresent()
-						&& todo.getChange().get() instanceof final Reconfiguration r)
-				.map(todo -> ((Reconfiguration) todo.getChange().get()).getAppliedPolicy())
-				.filter(policy -> policy.getId().equals(matchee.getId()))
-				.findAny().isPresent();
+				.filter(todo -> todo.getStart().equals(state)
+						&& todo.getChange().isPresent()
+						&& todo.getChange().get() instanceof Reconfiguration
+						&& ((Reconfiguration) todo.getChange().get()).getAppliedPolicy().getId()
+								.equals(matchee.getId()))
+				.findAny()
+				.isPresent();
 
 	}
 
 	public boolean hasOutTransitionFor(final RawModelState vertex, final ScalingPolicy matchee) {
 		return this.outgoingEdgesOf(vertex).stream()
-				.filter(t -> t.getChange().isPresent())
-				.map(t -> t.getChange().get())
-				.filter(c -> c instanceof final Reconfiguration r)
-				.map(c -> ((Reconfiguration) c).getAppliedPolicy())
-				.filter(policy -> policy.getId().equals(matchee.getId()))
+				.filter(t -> t.getChange().isPresent()
+						&& t.getChange().get() instanceof Reconfiguration
+						&& ((Reconfiguration) t.getChange().get()).getAppliedPolicy().getId().equals(matchee.getId()))
 				.findAny()
 				.isPresent();
 	}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultGraph.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultGraph.java
@@ -1,6 +1,5 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph;
 
-import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.Set;
 
@@ -28,8 +27,6 @@ public class DefaultGraph extends SimpleDirectedWeightedGraph<RawModelState, Raw
 	 */
 	private static final long serialVersionUID = -7468814179743463536L;
 
-	private final ArrayDeque<ToDoChange> fringe;
-
 	private final DefaultState root;
 
 	/**
@@ -42,21 +39,9 @@ public class DefaultGraph extends SimpleDirectedWeightedGraph<RawModelState, Raw
 
 		this.root = this.insertStateFor(0.0, rootArchConfig);
 		this.root.setSnapshot(new InMemorySnapshot(Set.of()));
-
-		this.fringe = new ArrayDeque<ToDoChange>();
 	}
 
-	/**
-	 * Select the change for the next exploration cycle.
-	 *
-	 * Current strategy is FIFO, but should be improved to something more
-	 * intelligent later on.
-	 *
-	 * @return
-	 */
-	public ToDoChange getNext() {
-		return this.fringe.poll();
-	}
+
 
 	public DefaultTransition insertTransitionFor(final Optional<Change> change, final RawModelState source,
 			final RawModelState target) {
@@ -70,34 +55,6 @@ public class DefaultGraph extends SimpleDirectedWeightedGraph<RawModelState, Raw
 		final DefaultState newState = new DefaultState(pointInTime, archConfig, this);
 		this.addVertex(newState);
 		return newState;
-	}
-
-	/**
-	 *
-	 * @return true, iff there's another change to explore, false otherwise
-	 */
-	public Boolean hasNext() {
-		return !this.fringe.isEmpty();
-	}
-
-	/**
-	 * The fringe are the Changes to be
-	 * @param edge
-	 */
-	public void addFringeEdge(final ToDoChange edge) {
-		fringe.add(edge);
-	}
-
-	public boolean hasInFringe(final DefaultState state, final ScalingPolicy matchee) {
-		return this.fringe.stream()
-				.filter(todo -> todo.getStart().equals(state)
-						&& todo.getChange().isPresent()
-						&& todo.getChange().get() instanceof Reconfiguration
-						&& ((Reconfiguration) todo.getChange().get()).getAppliedPolicy().getId()
-						.equals(matchee.getId()))
-				.findAny()
-				.isPresent();
-
 	}
 
 	public boolean hasOutTransitionFor(final RawModelState vertex, final ScalingPolicy matchee) {

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultGraphFringe.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultGraphFringe.java
@@ -1,0 +1,48 @@
+package org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph;
+
+import java.util.ArrayDeque;
+
+import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.Reconfiguration;
+import org.palladiosimulator.spd.ScalingPolicy;
+
+/**
+ *
+ * Fringe that manages the {@link ToDoChange}, i.e. all future directions to
+ * explore.
+ *
+ * TODO: Make this something with priority, such that the most interesting
+ * {@link ToDoChange} gets polled and thus explored first.
+ *
+ *
+ * @author Sarah Stieß
+ *
+ */
+public class DefaultGraphFringe extends ArrayDeque<ToDoChange> {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = -698254304773541924L;
+
+	/**
+	 * Check, whether the fringe already contains a {@link ToDoChange} that applies
+	 * {@code matchee} to {@code state}.
+	 *
+	 * @param state
+	 * @param matchee
+	 * @return true if a {@link ToDoChange} that applies {@code matchee} to
+	 *         {@code state} if in the fringe, false otherwise.
+	 */
+	public boolean containsTodoFor(final DefaultState state, final ScalingPolicy matchee) {
+		return this.stream()
+				.filter(todo -> todo.getStart().equals(state)
+						&& todo.getChange().isPresent()
+						&& todo.getChange().get() instanceof Reconfiguration
+						&& ((Reconfiguration) todo.getChange().get()).getAppliedPolicy().getId()
+						.equals(matchee.getId()))
+				.findAny()
+				.isPresent();
+	}
+
+
+}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
@@ -36,7 +36,7 @@ public class DefaultState implements RawModelState {
 	/* known after configuration of the simulation run */
 	private ExperimentSetting experimentSetting;
 
-	public DefaultState(final double pointInTime, final ArchitectureConfiguration archConfig,
+	protected DefaultState(final double pointInTime, final ArchitectureConfiguration archConfig,
 			final DefaultGraph graph) {
 		this.graph = graph;
 		this.startTime = pointInTime;

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
@@ -1,8 +1,11 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph;
 
+import java.util.Set;
+
 import org.palladiosimulator.analyzer.slingshot.snapshot.api.Snapshot;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.ArchitectureConfiguration;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.RawModelState;
+import org.palladiosimulator.analyzer.slingshot.stateexploration.api.RawTransition;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.ReasonToLeave;
 import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
 
@@ -18,16 +21,14 @@ import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
  */
 public class DefaultState implements RawModelState {
 
+	private final DefaultGraph graph;
+
 	/* known at start */
 	private final double startTime;
 	private final ArchitectureConfiguration archConfig;
 
 	/* known at the end */
 	private double duration;
-	/**
-	 * at first misused to get the snapshot to init on into the simulation. Later on
-	 * set to the actual snapshot of the events at the end of this state.
-	 */
 	private Snapshot snapshot;
 	private ReasonToLeave reasonToLeave;
 	private boolean decreaseInterval = false;
@@ -35,7 +36,9 @@ public class DefaultState implements RawModelState {
 	/* known after configuration of the simulation run */
 	private ExperimentSetting experimentSetting;
 
-	public DefaultState(final double pointInTime, final ArchitectureConfiguration archConfig) {
+	public DefaultState(final double pointInTime, final ArchitectureConfiguration archConfig,
+			final DefaultGraph graph) {
+		this.graph = graph;
 		this.startTime = pointInTime;
 		this.archConfig = archConfig;
 		this.reasonToLeave = ReasonToLeave.interval;
@@ -109,6 +112,19 @@ public class DefaultState implements RawModelState {
 	@Override
 	public String toString() {
 		return "DefaultState [archConfig=" + archConfig.getSegment() + ", reasonToLeave=" + reasonToLeave + "]";
+	}
+
+	@Override
+	public RawTransition getIncomingTransition() {
+		assert this.graph.incomingEdgesOf(this).size() == 1 : String.format("Illegal number of incoming edges for state %s.", this.toString());
+
+		return this.graph.incomingEdgesOf(this).stream().findFirst().orElseThrow(
+				() -> new IllegalStateException(String.format("Missing incoming edge for state %s.", this.toString())));
+	}
+
+	@Override
+	public Set<RawTransition> getOutgoingTransitions() {
+		return this.graph.outgoingEdgesOf(this);
 	}
 
 }

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultState.java
@@ -1,16 +1,10 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.palladiosimulator.analyzer.slingshot.snapshot.api.Snapshot;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.ArchitectureConfiguration;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.RawModelState;
-import org.palladiosimulator.analyzer.slingshot.stateexploration.api.RawTransition;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.ReasonToLeave;
-import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.Reconfiguration;
 import org.palladiosimulator.edp2.models.ExperimentData.ExperimentSetting;
-import org.palladiosimulator.spd.ScalingPolicy;
 
 /**
  * State in the raw state graph.
@@ -41,13 +35,9 @@ public class DefaultState implements RawModelState {
 	/* known after configuration of the simulation run */
 	private ExperimentSetting experimentSetting;
 
-	/* changes upon creation of successive states */
-	private final Set<RawTransition> outTransitions;
-
 	public DefaultState(final double pointInTime, final ArchitectureConfiguration archConfig) {
 		this.startTime = pointInTime;
 		this.archConfig = archConfig;
-		this.outTransitions = new HashSet<RawTransition>();
 		this.reasonToLeave = ReasonToLeave.interval;
 	}
 
@@ -75,27 +65,12 @@ public class DefaultState implements RawModelState {
 		this.decreaseInterval = decreaseInterval;
 	}
 
-	public void addOutTransition(final RawTransition transition) {
-		this.outTransitions.add(transition);
-	}
-
 	public void setReasonToLeave(final ReasonToLeave reasonToLeave) {
 		this.reasonToLeave = reasonToLeave;
 	}
 
 	public void setDuration(final double duration) {
 		this.duration = duration;
-	}
-
-	public boolean hasOutTransitionFor(final ScalingPolicy matchee) {
-		return this.outTransitions.stream()
-				.filter(t -> t.getChange().isPresent())
-				.map(t -> t.getChange().get())
-				.filter(c -> c instanceof final Reconfiguration r)
-				.map(c -> ((Reconfiguration) c).getAppliedPolicy())
-				.filter(policy -> policy.getId().equals(matchee.getId()))
-				.findAny()
-				.isPresent();
 	}
 
 	/* to match the interface */
@@ -110,10 +85,6 @@ public class DefaultState implements RawModelState {
 		return this.getExperimentSetting();
 	}
 
-	@Override
-	public Set<RawTransition> getOutTransitions() {
-		return outTransitions;
-	}
 
 	@Override
 	public ReasonToLeave getReasonToLeave() {

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultTransition.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultTransition.java
@@ -1,51 +1,35 @@
 package org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph;
 
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.RawModelState;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.api.RawTransition;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.Change;
-import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.ModelElementDifference;
-import org.palladiosimulator.pcm.core.entity.Entity;
 
 public class DefaultTransition implements RawTransition {
 	private final Optional<Change> change;
-	private final Set<ModelElementDifference<Entity>> modelDiff;
-	private final DefaultState start;
-	private final DefaultState end;
 
+	private final DefaultGraph graph;
 
-	public DefaultTransition(final Optional<Change> change, final DefaultState start, final DefaultState end) {
+	public DefaultTransition(final Optional<Change> change, final DefaultGraph graph) {
 		super();
 		this.change = change;
-		this.start = start;
-		this.end = end;
-		this.modelDiff = new HashSet<>();
+		this.graph = graph;
 	}
 
-	public void addDifferences(final Set<ModelElementDifference<Entity>> diffs) {
-		this.modelDiff.addAll(diffs);
-	}
 
 	@Override
 	public RawModelState getSource() {
-		return this.start;
+		return this.graph.getEdgeSource(this);
 	}
 
 	@Override
 	public RawModelState getTarget() {
-		return this.end;
+		return this.graph.getEdgeTarget(this);
 	}
 
 	@Override
 	public Optional<Change> getChange() {
 		return this.change;
-	}
-
-	@Override
-	public Set<ModelElementDifference<Entity>> getModelDifferences() {
-		return this.modelDiff;
 	}
 }

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultTransition.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration.data/src/org/palladiosimulator/analyzer/slingshot/stateexploration/rawgraph/DefaultTransition.java
@@ -11,7 +11,7 @@ public class DefaultTransition implements RawTransition {
 
 	private final DefaultGraph graph;
 
-	public DefaultTransition(final Optional<Change> change, final DefaultGraph graph) {
+	protected DefaultTransition(final Optional<Change> change, final DefaultGraph graph) {
 		super();
 		this.change = change;
 		this.graph = graph;

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/DefaultGraphExplorer.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/DefaultGraphExplorer.java
@@ -227,7 +227,8 @@ public class DefaultGraphExplorer implements GraphExplorer {
 
 		final double interval = config.getExplorationDuration();
 
-		final boolean notRootSuccesor = this.graph.getRoot().getOutTransitions().stream()
+		final Set<RawTransition> rootOutEdges = this.graph.outgoingEdgesOf(this.graph.getRoot());
+		final boolean notRootSuccesor = rootOutEdges.stream()
 				.filter(t -> t.getTarget().equals(config.getStateToExplore())).findAny().isEmpty();
 
 		return new SnapshotConfiguration(interval, notRootSuccesor, 0.5);

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/DefaultGraphExplorer.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/DefaultGraphExplorer.java
@@ -26,6 +26,7 @@ import org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.ui.Exp
 import org.palladiosimulator.analyzer.slingshot.stateexploration.providers.AdditionalConfigurationModule;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.providers.EventsToInitOnWrapper;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraph;
+import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraphFringe;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultState;
 import org.palladiosimulator.analyzer.slingshot.workflow.WorkflowConfigurationModule;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
@@ -57,6 +58,7 @@ public class DefaultGraphExplorer implements GraphExplorer {
 	private final ExplorationPlanner blackbox;
 
 	private final DefaultGraph graph;
+	private final DefaultGraphFringe fringe;
 
 	private final IProgressMonitor monitor;
 
@@ -77,11 +79,12 @@ public class DefaultGraphExplorer implements GraphExplorer {
 
 		this.graph = new DefaultGraph(
 				UriBasedArchitectureConfiguration.createRootArchConfig(this.initModels.getResourceSet()));
+		this.fringe = new DefaultGraphFringe();
 
 		systemDriver.postEvent(
 				new StateExploredMessage(StateGraphConverter.convertState(this.graph.getRoot(), null, null)));
 
-		this.blackbox = new ExplorationPlanner(this.graph, this.getMinDuration());
+		this.blackbox = new ExplorationPlanner(this.graph, this.fringe, this.getMinDuration());
 	}
 
 	@Override
@@ -90,7 +93,7 @@ public class DefaultGraphExplorer implements GraphExplorer {
 
 		for (int i = 0; i < this.getMaxIterations(); i++) { // just random.
 			LOGGER.warn("********** Iteration " + i + "**********");
-			if (!this.graph.hasNext()) {
+			if (this.fringe.isEmpty()) {
 				LOGGER.info(String.format("Fringe is empty. Stop Exloration after %d iterations.", i));
 				break;
 			}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
@@ -158,10 +158,10 @@ public class ExplorationPlanner {
 		final ArchitectureConfiguration newConfig = predecessor.getArchitecureConfiguration().copy();
 		final DefaultState newNode = new DefaultState(predecessor.getEndTime(), newConfig);
 
-		this.rawgraph.addNode(newNode);
+		this.rawgraph.addVertex(newNode);
 
 		final DefaultTransition nextTransition = new DefaultTransition(next.getChange(), predecessor, newNode);
-		predecessor.addOutTransition(nextTransition);
+		this.rawgraph.addEdge(nextTransition.getSource(), nextTransition.getTarget(), nextTransition);
 
 		return newNode;
 	}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
@@ -156,12 +156,12 @@ public class ExplorationPlanner {
 		final DefaultState predecessor = next.getStart();
 
 		final ArchitectureConfiguration newConfig = predecessor.getArchitecureConfiguration().copy();
-		final DefaultState newNode = new DefaultState(predecessor.getEndTime(), newConfig);
+		final DefaultState newNode = new DefaultState(predecessor.getEndTime(), newConfig, this.rawgraph);
 
 		this.rawgraph.addVertex(newNode);
 
-		final DefaultTransition nextTransition = new DefaultTransition(next.getChange(), predecessor, newNode);
-		this.rawgraph.addEdge(nextTransition.getSource(), nextTransition.getTarget(), nextTransition);
+		final DefaultTransition nextTransition = new DefaultTransition(next.getChange(), this.rawgraph);
+		this.rawgraph.addEdge(predecessor, newNode, nextTransition);
 
 		return newNode;
 	}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
@@ -14,6 +14,7 @@ import org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.config
 import org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.planning.strategies.BacktrackPolicyStrategy;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.planning.strategies.ProactivePolicyStrategy;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraph;
+import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraphFringe;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultState;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.ToDoChange;
 import org.palladiosimulator.spd.SPD;
@@ -36,18 +37,20 @@ public class ExplorationPlanner {
 	private static final Logger LOGGER = Logger.getLogger(ExplorationPlanner.class.getName());
 
 	private final DefaultGraph rawgraph;
+	private final DefaultGraphFringe fringe;
 	private final CutOffConcerns cutOffConcerns;
 
 	private final ProactivePolicyStrategy proactivePolicyStrategy;
 
 	private final double minDuration;
 
-	public ExplorationPlanner(final DefaultGraph graph, final double minDuration) {
+	public ExplorationPlanner(final DefaultGraph graph, final DefaultGraphFringe fringe, final double minDuration) {
 		this.rawgraph = graph;
+		this.fringe = fringe;
 		this.minDuration = minDuration;
 		this.cutOffConcerns = new CutOffConcerns();
 
-		this.proactivePolicyStrategy = new BacktrackPolicyStrategy(this.rawgraph);
+		this.proactivePolicyStrategy = new BacktrackPolicyStrategy(this.rawgraph, this.fringe);
 
 		this.updateGraphFringePostSimulation(graph.getRoot());
 	}
@@ -58,14 +61,14 @@ public class ExplorationPlanner {
 	 * @return Configuration for the next simulation run
 	 */
 	public SimulationInitConfiguration createConfigForNextSimualtionRun() {
-		assert this.rawgraph.hasNext();
+		assert !this.fringe.isEmpty();
 
-		ToDoChange next = this.rawgraph.getNext();
+		ToDoChange next = this.fringe.poll();
 
 		while (!this.cutOffConcerns.shouldExplore(next)) {
 			LOGGER.debug(String.format("Future %s is bad, won't explore.", next.toString()));
 			// TODO : Exception if the entire fringe is bad.
-			next = this.rawgraph.getNext();
+			next = this.fringe.poll();
 		}
 
 		final DefaultState start = next.getStart();
@@ -121,20 +124,20 @@ public class ExplorationPlanner {
 	 */
 	public void updateGraphFringePostSimulation(final DefaultState start) {
 		// NOP Always
-		this.rawgraph.addFringeEdge(new ToDoChange(Optional.empty(), start));
+		this.fringe.add(new ToDoChange(Optional.empty(), start));
 		// Reactive Reconfiguration - Always.
 		if (start.getSnapshot().getModelAdjustmentRequestedEvent().isPresent()) {
 			final ModelAdjustmentRequested event = start.getSnapshot().getModelAdjustmentRequestedEvent().get();
 
 			// reactive reconf to the next state.
-			this.rawgraph.addFringeEdge(new ToDoChange(Optional.of(new ReactiveReconfiguration(event)), start));
+			this.fringe.add(new ToDoChange(Optional.of(new ReactiveReconfiguration(event)), start));
 		}
 
 		// proactive reconf.
 		final List<ToDoChange> proactiveChanges = this.proactivePolicyStrategy.createProactiveChanges(start);
 
 		for (final ToDoChange toDoChange : proactiveChanges) {
-			this.rawgraph.addFringeEdge(toDoChange);
+			this.fringe.add(toDoChange);
 		}
 	}
 
@@ -187,13 +190,12 @@ public class ExplorationPlanner {
 	 * @param offset duration of the previous state
 	 */
 	private void reduceSimulationTimeTriggerExpectedTime(final SPD spd, final double offset) {
-
-		// get all triggers on Fixed point in time.
-		spd.getScalingPolicies().stream().filter(policy -> policy.isActive()).map(policy -> policy.getScalingTrigger())
-		.filter(BaseTrigger.class::isInstance).map(BaseTrigger.class::cast)
-		.filter(trigger -> trigger.getStimulus() instanceof SimulationTime)
-		.map(trigger -> trigger.getExpectedValue()).filter(ExpectedTime.class::isInstance)
-		.map(ExpectedTime.class::cast).forEach(time -> this.updateValue(time, offset));
+		spd.getScalingPolicies().stream()
+				.filter(policy -> policy.isActive() && policy.getScalingTrigger() instanceof BaseTrigger)
+				.map(policy -> ((BaseTrigger) policy.getScalingTrigger()))
+				.filter(trigger -> trigger.getStimulus() instanceof SimulationTime
+				&& trigger.getExpectedValue() instanceof ExpectedTime)
+				.forEach(trigger -> this.updateValue(((ExpectedTime) trigger.getExpectedValue()), offset));
 
 		ResourceUtils.saveResource(spd.eResource());
 	}
@@ -201,8 +203,8 @@ public class ExplorationPlanner {
 	/**
 	 * update value helper.
 	 *
-	 * @param time
-	 * @param previousStateDuration
+	 * @param time                  model element to be updated
+	 * @param previousStateDuration duration to subtract from {@code time}.
 	 */
 	private void updateValue(final ExpectedTime time, final double previousStateDuration) {
 		final double triggerTime = time.getValue();

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/ExplorationPlanner.java
@@ -15,7 +15,6 @@ import org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.planni
 import org.palladiosimulator.analyzer.slingshot.stateexploration.explorer.planning.strategies.ProactivePolicyStrategy;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraph;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultState;
-import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultTransition;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.ToDoChange;
 import org.palladiosimulator.spd.SPD;
 import org.palladiosimulator.spd.ScalingPolicy;
@@ -156,12 +155,9 @@ public class ExplorationPlanner {
 		final DefaultState predecessor = next.getStart();
 
 		final ArchitectureConfiguration newConfig = predecessor.getArchitecureConfiguration().copy();
-		final DefaultState newNode = new DefaultState(predecessor.getEndTime(), newConfig, this.rawgraph);
+		final DefaultState newNode = this.rawgraph.insertStateFor(minDuration, newConfig);
 
-		this.rawgraph.addVertex(newNode);
-
-		final DefaultTransition nextTransition = new DefaultTransition(next.getChange(), this.rawgraph);
-		this.rawgraph.addEdge(predecessor, newNode, nextTransition);
+		this.rawgraph.insertTransitionFor(next.getChange(), predecessor, newNode);
 
 		return newNode;
 	}

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/strategies/BacktrackPolicyStrategy.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/strategies/BacktrackPolicyStrategy.java
@@ -65,7 +65,7 @@ public class BacktrackPolicyStrategy extends ProactivePolicyStrategy {
 	 * @return
 	 */
 	private boolean policyAlreadyExploredAtState(final DefaultState state, final ScalingPolicy policy) {
-		return state.hasOutTransitionFor(policy) || this.graph.hasInFringe(state, policy);
+		return this.graph.hasOutTransitionFor(state, policy) || this.graph.hasInFringe(state, policy);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/strategies/BacktrackPolicyStrategy.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/strategies/BacktrackPolicyStrategy.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.palladiosimulator.analyzer.slingshot.behavior.spd.data.ModelAdjustmentRequested;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.change.api.ProactiveReconfiguration;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraph;
+import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultGraphFringe;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.DefaultState;
 import org.palladiosimulator.analyzer.slingshot.stateexploration.rawgraph.ToDoChange;
 import org.palladiosimulator.spd.ScalingPolicy;
@@ -25,9 +26,11 @@ import org.palladiosimulator.spd.ScalingPolicy;
 public class BacktrackPolicyStrategy extends ProactivePolicyStrategy {
 
 	private final DefaultGraph graph;
+	private final DefaultGraphFringe fringe;
 
-	public BacktrackPolicyStrategy(final DefaultGraph graph) {
+	public BacktrackPolicyStrategy(final DefaultGraph graph, final DefaultGraphFringe fringe) {
 		this.graph = graph;
+		this.fringe = fringe;
 	}
 
 	@Override
@@ -65,7 +68,7 @@ public class BacktrackPolicyStrategy extends ProactivePolicyStrategy {
 	 * @return
 	 */
 	private boolean policyAlreadyExploredAtState(final DefaultState state, final ScalingPolicy policy) {
-		return this.graph.hasOutTransitionFor(state, policy) || this.graph.hasInFringe(state, policy);
+		return this.graph.hasOutTransitionFor(state, policy) || this.fringe.containsTodoFor(state, policy);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/strategies/BacktrackPolicyStrategy.java
+++ b/org.palladiosimulator.analyzer.slingshot.stateexploration/src/org/palladiosimulator/analyzer/slingshot/stateexploration/explorer/planning/strategies/BacktrackPolicyStrategy.java
@@ -57,7 +57,7 @@ public class BacktrackPolicyStrategy extends ProactivePolicyStrategy {
 
 	/**
 	 * Check whether {@code state} already transitioned to a successor, via the
-	 * given policy. Or wether it is already planned to explore that (i.e.
+	 * given policy. Or whether it is already planned to explore that (i.e.
 	 * corresponding change in the fringe)
 	 *
 	 * @param state


### PR DESCRIPTION
# Current Behaviour
* Stategraph is all selfmade.
* Fringe is a Queue inside the stategraph.

# New Behaviour
* Stategraph extends `SimpleDirectedGraph` from JGraph Library. Graph itself, States and Transitions make use of graph operations. 
* Original Interfaces remain (mostly) unchanged, but implementation uses operations offered by the library. 
* Fringe get its on class and is no longer a fixed part of the graph. Intention: at some point we want something more elaborate than FIFO for the fringe. 