### PR TITLE
ignore lower SLO violations for ARMP, is system is already at min config.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.snapshot/META-INF/MANIFEST.MF
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/META-INF/MANIFEST.MF
@@ -30,5 +30,6 @@ Require-Bundle: org.apache.log4j,
  org.palladiosimulator.analyzer.workflow,
  org.palladiosimulator.analyzer.slingshot.behavior.usageevolution,
  org.palladiosimulator.servicelevelobjective,
- org.palladiosimulator.analyzer.slingshot.behavior.spd
+ org.palladiosimulator.analyzer.slingshot.behavior.spd,
+ org.palladiosimulator.pcm.edp2.measuringpoint
 Export-Package: org.palladiosimulator.analyzer.slingshot.snapshot

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotSLOTriggeringBehavior.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotSLOTriggeringBehavior.java
@@ -136,12 +136,10 @@ public class SnapshotSLOTriggeringBehavior implements SimulationBehaviorExtensio
 
 		for (final ValueRange range : mp2range.get(spec)) {
 			if (range.isViolatedBy(calculationValue)) {
-				if (range.isLowerViolatedBy(calculationValue)) {
-					if (spec.getMonitor().getMeasuringPoint() instanceof final ActiveResourceMeasuringPoint armp) {
-						if (this.isMinimalConfig(armp)) {
-							continue;
-						}
-					}
+				if (range.isLowerViolatedBy(calculationValue)
+						&& spec.getMonitor().getMeasuringPoint() instanceof final ActiveResourceMeasuringPoint armp
+						&& this.isMinimalConfig(armp)) {
+					continue;
 				}
 				state.setReasonToLeave(ReasonToLeave.closenessToSLO);
 				LOGGER.debug(String.format(


### PR DESCRIPTION
### Current behaviour.

If system is underutilised, we keep getting measurements of $0$ for the AR MPs (active resource measuring points), which keeps triggern snapshots. how ever, if the system is already at its minimal configuration (i.e. all scaled in), this is useless, as we cannot scale in further anyway. 

### New behaviour. 

If a snapshot shall be triggered due to closeness to the lower bound of an SLO on an AR MP, we only trigger if the measurement from an EI config, where $abs(elements) > 1$.  Because if $abs(elements) = 1$, it is only the `unit` container, which must not be scaled away.