### PR TITLE
refactor handling for cost.

### DIFF
--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelper.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelper.java
@@ -45,7 +45,6 @@ import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.Inter
 import org.palladiosimulator.analyzer.slingshot.behavior.usagemodel.events.UsageModelPassedElement;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.common.utils.events.ModelPassedEvent;
-import org.palladiosimulator.analyzer.slingshot.cost.events.IntervalPassed;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 import org.palladiosimulator.pcm.allocation.AllocationContext;
 import org.palladiosimulator.pcm.core.CoreFactory;
@@ -116,17 +115,6 @@ public final class CloneHelper {
 	 */
 	public DESEvent clone(final InterArrivalUserInitiated event, final double simulationTime) {
 		return new InterArrivalUserInitiated(event.getEntity(), event.time() - simulationTime);
-	}
-
-	/**
-	 * TODO on a closer look : what is this does not belong here, iirc o_O
-	 *
-	 * @param event
-	 * @param simulationTime
-	 * @return
-	 */
-	public DESEvent clone(final IntervalPassed event, final double simulationTime) {
-		return new IntervalPassed(event.getTargetResourceContainer(), event.time() - simulationTime);
 	}
 
 	/**

--- a/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelperWithVisitor.java
+++ b/org.palladiosimulator.analyzer.slingshot.behavior.util/src/org/palladiosimulator/analyzer/slingshot/behavior/util/CloneHelperWithVisitor.java
@@ -23,7 +23,6 @@ import org.palladiosimulator.analyzer.slingshot.behavior.util.visitors.ModelElem
 import org.palladiosimulator.analyzer.slingshot.behavior.util.visitors.SEFFInterpretedVisitor;
 import org.palladiosimulator.analyzer.slingshot.behavior.util.visitors.UserChangedEventVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
-import org.palladiosimulator.analyzer.slingshot.cost.events.IntervalPassed;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 public class CloneHelperWithVisitor {
@@ -50,7 +49,6 @@ public class CloneHelperWithVisitor {
 				on(UserRequestFinished.class).then(this::clone).
 				on(UserEntryRequested.class).then(this::clone).
 				on(InterArrivalUserInitiated.class).then(this::clone).
-				on(IntervalPassed.class).then(this::clone).
 				on(SPDAdjustorStateInitialized.class).then(this::clone).
 				on(DESEvent.class).then(this::log);
 	}
@@ -92,10 +90,6 @@ public class CloneHelperWithVisitor {
 		final UserRequest clonedRequest = helper.cloneUserRequest(clonee.getEntity());
 		final UserInterpretationContext clonedContext = helper.cloneUserInterpretationContext(clonee.getUserContext());
 		return new UserRequestFinished(clonedRequest, clonedContext);
-	}
-
-	private DESEvent clone(final IntervalPassed clonee) {
-		return new IntervalPassed(clonee);
 	}
 
 	private DESEvent clone(final SPDAdjustorStateInitialized clonee) {

--- a/org.palladiosimulator.analyzer.slingshot.snapshot.data/src/org/palladiosimulator/analyzer/slingshot/snapshot/entities/LessInvasiveInMemoryCamera.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot.data/src/org/palladiosimulator/analyzer/slingshot/snapshot/entities/LessInvasiveInMemoryCamera.java
@@ -21,7 +21,6 @@ import org.palladiosimulator.analyzer.slingshot.behavior.util.CloneHelperWithVis
 import org.palladiosimulator.analyzer.slingshot.behavior.util.LambdaVisitor;
 import org.palladiosimulator.analyzer.slingshot.common.events.DESEvent;
 import org.palladiosimulator.analyzer.slingshot.core.api.SimulationEngine;
-import org.palladiosimulator.analyzer.slingshot.cost.events.IntervalPassed;
 import org.palladiosimulator.analyzer.slingshot.snapshot.api.Camera;
 import org.palladiosimulator.analyzer.slingshot.snapshot.api.Snapshot;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
@@ -53,7 +52,6 @@ public final class LessInvasiveInMemoryCamera implements Camera {
 				.on(SEFFModelPassedElement.class).then(this::clone)
 				.on(ClosedWorkloadUserInitiated.class).then(this::clone)
 				.on(InterArrivalUserInitiated.class).then(this::clone)
-				.on(IntervalPassed.class).then(this::clone)
 				.on(DESEvent.class).then(e -> e);
 	}
 
@@ -61,10 +59,6 @@ public final class LessInvasiveInMemoryCamera implements Camera {
 	public Snapshot takeSnapshot() {
 		final Snapshot snapshot = new InMemorySnapshot(snapEvents());
 		return snapshot;
-	}
-
-	private DESEvent clone(final IntervalPassed event) {
-		return helper.clone(event, engine.getSimulationInformation().currentSimulationTime());
 	}
 
 	private DESEvent clone(final UsageModelPassedElement<?> event) {

--- a/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
+++ b/org.palladiosimulator.analyzer.slingshot.snapshot/src/org/palladiosimulator/analyzer/slingshot/snapshot/SnapshotGraphStateBehaviour.java
@@ -82,7 +82,6 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 
 	/* helper */
 	private final Map<ModelPassedEvent<?>, Double> event2offset;
-	private final Map<String, TakeCostMeasurement> resourceContainer2intervalPassed;
 
 	private final boolean activated;
 
@@ -109,7 +108,6 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 		}
 
 		this.event2offset = new HashMap<>();
-		this.resourceContainer2intervalPassed = new HashMap<>();
 		this.policyIdToValues = new HashMap<>();
 	}
 
@@ -195,6 +193,21 @@ public class SnapshotGraphStateBehaviour implements SimulationBehaviorExtension 
 	Collection<TakeCostMeasurement> costMeasurementStore = new ArrayList<>();
 	boolean handleCosts = true;
 
+	/**
+	 *
+	 * Intercept {@link TakeCostMeasurement} events.
+	 *
+	 * For two reasons: Firstly, get to know all resources with cost measures to
+	 * trigger a measurement in case of a snapshot. Secondly, abort the events, if
+	 * the state starts with an adaptation. In this case, cost must only be measured
+	 * after the adaptation, c.f.
+	 * {@link SnapshotGraphStateBehaviour#onModelAdjusted(ModelAdjusted)}
+	 *
+	 *
+	 * @param information
+	 * @param event
+	 * @return success, if this state starts without adaptation, abort other wise.
+	 */
 	@PreIntercept
 	public InterceptionResult preInterceptTakeCostMeasurement(final InterceptorInformation information,
 			final TakeCostMeasurement event) {


### PR DESCRIPTION
#### Current behaviour
Cost are only measured according to the interval. 
This is problematic, if the duration of a state is shorter than the interval, because the state will have costs of 0.

#### New behaviour
Trigger a nother cost measurement at the end of every state, independent of the intervall.
Benefit: no more state with 0 costs.

#### Beware
Requires latest commit from the ..-Cost Extension Repository, because renames. 
